### PR TITLE
Clear input buffer and add inference time benchmarking

### DIFF
--- a/chat_main.py
+++ b/chat_main.py
@@ -5,6 +5,7 @@ import sys
 from dotenv import load_dotenv
 from OctoAiCloudLLM import OctoAiCloudLLM
 from langchain import LLMChain, PromptTemplate
+import time
 from termios import tcflush, TCIFLUSH
 
 # Get the current file's directory
@@ -63,9 +64,12 @@ def ask():
                 handle_exit()
 
             # Generate and print the response
+            start_time = time.time()
             response = llm_chain.run(user_prompt)
+            end_time = time.time()
+            elapsed_time = end_time-start_time
             response = str(response).lstrip("\n")
-            print("Response: " + response)
+            print(f"Response({round(elapsed_time,1)} sec): " + response)
     except KeyboardInterrupt:
         handle_exit()
 

--- a/chat_main.py
+++ b/chat_main.py
@@ -5,7 +5,6 @@ import sys
 from dotenv import load_dotenv
 from OctoAiCloudLLM import OctoAiCloudLLM
 from langchain import LLMChain, PromptTemplate
-from llama_index import LLMPredictor
 
 # Get the current file's directory
 current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -36,7 +35,6 @@ def ask():
 
     # Set up the language model and predictor
     llm = OctoAiCloudLLM(endpoint_url=endpoint_url)
-    llm_predictor = LLMPredictor(llm=llm)
 
     # Define a prompt template
     template = "{question}"

--- a/chat_main.py
+++ b/chat_main.py
@@ -5,6 +5,7 @@ import sys
 from dotenv import load_dotenv
 from OctoAiCloudLLM import OctoAiCloudLLM
 from langchain import LLMChain, PromptTemplate
+from termios import tcflush, TCIFLUSH
 
 # Get the current file's directory
 current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -54,6 +55,7 @@ def ask():
     print("Example \n\nPrompt:", example_question, "\n\nResponse:", llm_chain.run(example_question))
         
     try:
+        tcflush(sys.stdin, TCIFLUSH)
         while True:
             # Collect user's prompt
             user_prompt = input("\nPrompt: ")

--- a/pdf_qa_main.py
+++ b/pdf_qa_main.py
@@ -8,6 +8,9 @@ from OctoAiCloudLLM import OctoAiCloudLLM
 from langchain import HuggingFaceHub, OpenAI, PromptTemplate, LLMChain
 from langchain.embeddings import HuggingFaceEmbeddings
 from llama_index import ( LLMPredictor, ServiceContext, download_loader, GPTVectorStoreIndex, LangchainEmbedding)
+import time
+from termios import tcflush, TCIFLUSH
+
 # Get the current file's directory
 current_dir = os.path.dirname(os.path.abspath(__file__))
 # Change the current working directory
@@ -77,18 +80,22 @@ def ask(file):
     print("Press Ctrl+C to exit")
 
     try:
+        tcflush(sys.stdin, TCIFLUSH)
         while True:
             prompt = input("\nPrompt: ")
             if prompt == "exit":
                 handle_exit()
 
+            start_time = time.time()
             response = query_engine.query(prompt)
+            end_time = time.time()
+            elapsed_time = end_time-start_time              
             print()
 
             # Transform response to string and remove leading newline character if present
             response = str(response).lstrip("\n")
 
-            print("Response: " + response)
+            print(f"Response({round(elapsed_time,1)} sec): " + response)
     except KeyboardInterrupt:
         handle_exit()
 


### PR DESCRIPTION
Here is a small PR with 2 improvements:
* clear input buffer before reading user input: this solves the problem of loading existing text in the terminal from the previous command
* add benchmarking for LLM inference: this shows the number of seconds spent in inference in the printed response